### PR TITLE
UI Test: Support high dpi displays for UI testing

### DIFF
--- a/src/Samples.UITest/UITest.Core/UITestBase.cs
+++ b/src/Samples.UITest/UITest.Core/UITestBase.cs
@@ -6,6 +6,7 @@ using FlaUI.UIA3;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xunit.Abstractions;
 
 namespace UITest;
@@ -17,6 +18,7 @@ public abstract class UITestBase : IDisposable
 
     static UITestBase()
     {
+        NativeMethods.SetProcessDPIAware();
         CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
 
         Mouse.MovePixelsPerMillisecond = 2;
@@ -110,5 +112,12 @@ public abstract class UITestBase : IDisposable
         {
             if (File.Exists(file)) File.Delete(file);
         }
+    }
+
+
+    private static class NativeMethods
+    {
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool SetProcessDPIAware();
     }
 }


### PR DESCRIPTION
The unit test must run with high dpi support for the process so that UI automation (FlaUI) works correct on high dpi displays.

**Microsoft documentation:**
> First, make the client application dpi-aware. To do this, call the [SetProcessDPIAware](https://learn.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-setprocessdpiaware) function at startup. This function makes the entire process dpi-aware, meaning that all windows that belong to the process are unscaled.
- https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-screenscaling#scaling-in-ui-automation-clients


This PR calls `SetProcessDPIAware` to support this. 
Note: We cannot use the application manifest approach for high dpi support as the unit test will be run by an external process.

Related issues:
- https://github.com/FlaUI/FlaUI/issues/306
- https://github.com/FlaUI/FlaUI/issues/461