### PR TITLE
NewsReader: Workaround for Graph SDK and use MSAL Broker on Windows

### DIFF
--- a/src/NewsReader/Directory.Build.props
+++ b/src/NewsReader/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <MauiVersion>9.0.21</MauiVersion>
+    <MauiVersion>9.0.22</MauiVersion>
     
     <NeutralLanguage>en</NeutralLanguage>
     <Nullable>enable</Nullable>

--- a/src/NewsReader/Directory.Packages.props
+++ b/src/NewsReader/Directory.Packages.props
@@ -12,8 +12,7 @@
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="NLog" Version="5.3.4" />
     <PackageVersion Include="Microsoft.Graph" Version="5.68.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.67.2" />
-    <PackageVersion Include="Microsoft.Identity.Client.Desktop" Version="4.67.2" />
+    <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.67.2" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.67.2" />
     <PackageVersion Include="System.ServiceModel.Syndication" Version="9.0.1" />
     <PackageVersion Include="System.Waf.Core" Version="8.0.2-alpha.0.81" />

--- a/src/NewsReader/Directory.Packages.props
+++ b/src/NewsReader/Directory.Packages.props
@@ -11,17 +11,18 @@
     <PackageVersion Include="Autofac" Version="8.2.0" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="NLog" Version="5.3.4" />
-    <PackageVersion Include="Microsoft.Graph" Version="5.67.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.66.2" />
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.66.2" />
-    <PackageVersion Include="System.ServiceModel.Syndication" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Graph" Version="5.68.0" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.67.2" />
+    <PackageVersion Include="Microsoft.Identity.Client.Desktop" Version="4.67.2" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.67.2" />
+    <PackageVersion Include="System.ServiceModel.Syndication" Version="9.0.1" />
     <PackageVersion Include="System.Waf.Core" Version="8.0.2-alpha.0.81" />
 
     <!-- Unit tests -->
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
     <PackageVersion Include="System.Waf.UnitTesting.Core" Version="8.0.2-alpha.0.81" />
   </ItemGroup>
 </Project>

--- a/src/NewsReader/Directory.Packages.props
+++ b/src/NewsReader/Directory.Packages.props
@@ -21,8 +21,8 @@
     <!-- Unit tests -->
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
     <PackageVersion Include="System.Waf.UnitTesting.Core" Version="8.0.2-alpha.0.81" />
   </ItemGroup>
 </Project>

--- a/src/NewsReader/NewsReader.Presentation/App.xaml.cs
+++ b/src/NewsReader/NewsReader.Presentation/App.xaml.cs
@@ -43,6 +43,8 @@ public partial class App : Application
 
     public static string LogFileName { get; } = Path.Combine(FileSystem.CacheDirectory, "Logging", "AppLog.txt");
 
+    public static Window? CurrentWindow { get; private set; }
+
     protected override Window CreateWindow(IActivationState? activationState)
     {
         var window = new Window((Page)appController.MainView)
@@ -56,6 +58,7 @@ public partial class App : Application
         window.Stopped += (_, _) => OnStopped();
         window.Destroying += (_, _) => OnDestroying();
         window.Resumed += (_, _) => OnResumed();
+        CurrentWindow = window;
         return window;
     }
 

--- a/src/NewsReader/NewsReader.Presentation/NewsReader.Presentation.csproj
+++ b/src/NewsReader/NewsReader.Presentation/NewsReader.Presentation.csproj
@@ -16,13 +16,9 @@
     <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="$(MauiVersion)" />
 
     <PackageReference Include="Microsoft.Graph" />
-    <PackageReference Include="Microsoft.Identity.Client" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
     <PackageReference Include="System.ServiceModel.Syndication" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
-    <PackageReference Include="Microsoft.Identity.Client.Desktop" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NewsReader/NewsReader.Presentation/NewsReader.Presentation.csproj
+++ b/src/NewsReader/NewsReader.Presentation/NewsReader.Presentation.csproj
@@ -21,6 +21,10 @@
     <PackageReference Include="System.ServiceModel.Syndication" />
   </ItemGroup>
 
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+    <PackageReference Include="Microsoft.Identity.Client.Desktop" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\NewsReader.Applications\NewsReader.Applications.csproj" />
   </ItemGroup>

--- a/src/NewsReader/NewsReader.Presentation/Services/WebStorageService.cs
+++ b/src/NewsReader/NewsReader.Presentation/Services/WebStorageService.cs
@@ -41,7 +41,11 @@ internal sealed partial class WebStorageService : Model, IWebStorageService
 #elif IOS
             builder.WithIosKeychainSecurityGroup(Foundation.NSBundle.MainBundle.BundleIdentifier);
 #elif WINDOWS
-            Microsoft.Identity.Client.Desktop.DesktopExtensions.WithWindowsEmbeddedBrowserSupport(builder);
+            Microsoft.Identity.Client.Broker.BrokerExtension.WithBroker(builder, new BrokerOptions(BrokerOptions.OperatingSystems.Windows)
+            {
+                Title = AppInfo.Name
+            });
+            builder.WithParentActivityOrWindow(() => WinRT.Interop.WindowNative.GetWindowHandle(App.CurrentWindow!.Handler.PlatformView!));
 #endif
             publicClient = builder.Build();
         }

--- a/src/NewsReader/NewsReader.Presentation/Services/WebStorageService.cs
+++ b/src/NewsReader/NewsReader.Presentation/Services/WebStorageService.cs
@@ -2,7 +2,6 @@
 using Microsoft.Graph.Models;
 using Microsoft.Graph.Models.ODataErrors;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Client.Extensions.Msal;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Waf.NewsReader.Applications.Services;
 
@@ -41,6 +40,8 @@ internal sealed partial class WebStorageService : Model, IWebStorageService
             builder.WithParentActivityOrWindow(() => Platform.CurrentActivity);
 #elif IOS
             builder.WithIosKeychainSecurityGroup(Foundation.NSBundle.MainBundle.BundleIdentifier);
+#elif WINDOWS
+            Microsoft.Identity.Client.Desktop.DesktopExtensions.WithWindowsEmbeddedBrowserSupport(builder);
 #endif
             publicClient = builder.Build();
         }
@@ -61,8 +62,8 @@ internal sealed partial class WebStorageService : Model, IWebStorageService
         if (!cacheInitialized && publicClient is not null)
         {
             cacheInitialized = true;
-            var storageProperties = new StorageCreationPropertiesBuilder("msal.dat", FileSystem.CacheDirectory).Build();
-            var cacheHelper = await MsalCacheHelper.CreateAsync(storageProperties);
+            var storageProperties = new Microsoft.Identity.Client.Extensions.Msal.StorageCreationPropertiesBuilder("msal.dat", FileSystem.CacheDirectory).Build();
+            var cacheHelper = await Microsoft.Identity.Client.Extensions.Msal.MsalCacheHelper.CreateAsync(storageProperties);
             cacheHelper.RegisterCache(publicClient.UserTokenCache);
         }
 #endif


### PR DESCRIPTION
Workaround for MS Graph to get the required driveId: 
- https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2624