### PR TITLE
Build: Downgrade Windows runner to 2022 as workaround for the missing…

### DIFF
--- a/.github/workflows/System.Waf.CI.yml
+++ b/.github/workflows/System.Waf.CI.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: 🛠️ Build and test
-    runs-on: windows-2025
+    runs-on: windows-2022
 
     steps:
     - name: 🔖 Check-out


### PR DESCRIPTION
… PDF printer (UI tests)

See:
- https://github.com/actions/runner-images/issues/12328